### PR TITLE
Added 3 extra lines on Core.cs in Void Remake menu on line 64, and 79.

### DIFF
--- a/ExpressionControl/Core.cs
+++ b/ExpressionControl/Core.cs
@@ -61,7 +61,9 @@ namespace ExpressionControl
 
             foreach (var keyPair in blendshapePairs)
             {
-                mainPage.CreateBool(keyPair.Key, Color.white, keyPair.Value, (b) =>
+                Color buttonColor = keyPair.Value ? Color.green : Color.red;
+                
+                mainPage.CreateBool(keyPair.Key, buttonColor, keyPair.Value, (b) =>
                 {
                     if (deletionMode)
                     {
@@ -74,6 +76,7 @@ namespace ExpressionControl
                         return;
                     }
                     blendshapePairs[keyPair.Key] = b;
+                    RemakeMenu();  //Redraw the menu to update colors
                     ApplyBlendshapesToLocalPlayer();
                     SaveDictToFile();
                     Broadcast();


### PR DESCRIPTION
Added 3 extra lines for color changing buttons, this should allow people to easily identify what blendshape you have on or off.
![image](https://github.com/user-attachments/assets/c5461567-4a2f-4909-ac8c-44534e152a8f)
![image](https://github.com/user-attachments/assets/6d8b5ade-c580-483b-8a37-6767e71d3f2d)
